### PR TITLE
fix keyref issues for Android and iOS

### DIFF
--- a/dita/RTC/API/api_setaudioprofile2.dita
+++ b/dita/RTC/API/api_setaudioprofile2.dita
@@ -13,7 +13,7 @@
     <refbody>
         <section id="prototype">
             <p outputclass="codeblock">
-                <codeblock props="android" outputclass="language-java">public synchronized int setAudioProfile(int profile) {</codeblock>
+                <codeblock props="android" outputclass="language-java">public synchronized int setAudioProfile(int profile)</codeblock>
                 <codeblock props="ios mac" outputclass="language-objectivec"/>
                 <codeblock props="windows" outputclass="language-cpp"/>
                 <codeblock props="electron" outputclass="language-typescript"/>

--- a/dita/RTC/RTC_NG_API_Android.ditamap
+++ b/dita/RTC/RTC_NG_API_Android.ditamap
@@ -36,6 +36,7 @@
             <topicref keyref="createMediaPlayer" toc="no"/>
             <topicref keyref="CreateRendererView" toc="no"/>
             <topicref keyref="CreateTextureView" toc="no"/>
+            <topicref keyref="release" toc="no"/>
             <topicref keyref="disableAudio" toc="no"/>
             <topicref keyref="disableAudioSpectrumMonitor" toc="no"/>
             <topicref keyref="disableVideo" toc="no"/>
@@ -48,7 +49,6 @@
             <topicref keyref="enableDualStreamMode3" toc="no"/>
             <topicref keyref="enableEncryption" toc="no"/>
             <topicref keyref="enableExtension" toc="no"/>
-            <topicref keyref="enableExternalAudioSourceLocalPlayback" toc="no"/>
             <topicref keyref="enableInEarMonitoring" toc="no"/>
             <topicref keyref="enableLocalAudio" toc="no"/>
             <topicref keyref="enableLocalVideo" toc="no"/>
@@ -96,10 +96,8 @@
             <topicref keyref="registerAudioFrameObserver" toc="no"/>
             <topicref keyref="registerAudioSpectrumObserver" toc="no"/>
             <topicref keyref="registerMediaMetadataObserver" toc="no"/>
-            <topicref keyref="registerMediaMetadataObserver" toc="no"/>
             <topicref keyref="registerVideoEncodedImageReceiver" toc="no"/>
             <topicref keyref="registerVideoFrameObserver" toc="no"/>
-            <topicref keyref="release" toc="no"/>
             <topicref keyref="removeHandler" toc="no"/>
             <topicref keyref="removeInjectStreamUrl" toc="no"/>
             <topicref keyref="removePublishStreamUrl" toc="no"/>
@@ -111,6 +109,7 @@
             <topicref keyref="setAudioEffectPreset" toc="no"/>
             <topicref keyref="setAudioMixingPosition" toc="no"/>
             <topicref keyref="setAudioProfile" toc="no"/>
+            <topicref keyref="setAudioProfile2" toc="no"/>
             <topicref keyref="setCameraAutoFocusFaceModeEnabled" toc="no"/>
             <topicref keyref="setCameraCapturerConfiguration" toc="no"/>
             <topicref keyref="setCameraExposurePosition" toc="no"/>
@@ -181,7 +180,6 @@
             <topicref keyref="stopPreview" toc="no"/>
             <topicref keyref="stopScreenCapture" toc="no"/>
             <topicref keyref="switchCamera" toc="no"/>
-            <topicref keyref="updateChannelMediaOptions" toc="no"/>
             <topicref keyref="unregisterAudioSpectrumObserver" toc="no"/>
             <topicref keyref="unregisterMediaMetadataObserver" toc="no"/>
             <topicref keyref="updateChannelMediaOptions" toc="no"/>
@@ -212,8 +210,6 @@
         <topicref keyref="IRtcEngineEventHandler" chunk="to-content">
             <topicref keyref="onActiveSpeaker" toc="no"/>
             <topicref keyref="onApiCallExecuted" toc="no"/>
-            <topicref keyref="onAudioDeviceStateChanged" toc="no"/>
-            <topicref keyref="onAudioDeviceVolumeChanged" toc="no"/>
             <topicref keyref="onAudioEffectFinished" toc="no"/>
             <topicref keyref="onAudioMixingFinished" toc="no"/>
             <topicref keyref="onAudioMixingStateChanged" toc="no"/>
@@ -232,7 +228,6 @@
             <topicref keyref="onConnectionInterrupted" toc="no"/>
             <topicref keyref="onConnectionLost" toc="no"/>
             <topicref keyref="onConnectionStateChanged" toc="no"/>
-            <topicref keyref="onDownlinkNetworkInfoUpdated" toc="no"/>
             <topicref keyref="onEncryptionError" toc="no"/>
             <topicref keyref="onFacePositionChanged" toc="no"/>
             <topicref keyref="onFirstLocalAudioFramePublished" toc="no"/>
@@ -256,8 +251,6 @@
             <topicref keyref="onNetworkTypeChanged" toc="no"/>
             <topicref keyref="onPermissionError" toc="no"/>
             <topicref keyref="onRejoinChannelSuccess" toc="no"/>
-            <topicref keyref="onRemoteAudioMixingBegin" toc="no"/>
-            <topicref keyref="onRemoteAudioMixingEnd" toc="no"/>
             <topicref keyref="onRemoteAudioStateChanged" toc="no"/>
             <topicref keyref="onRemoteAudioStats" toc="no"/>
             <topicref keyref="onRemoteAudioTransportStats" toc="no"/>
@@ -282,7 +275,6 @@
             <topicref keyref="onUserJoined" toc="no"/>
             <topicref keyref="onUserMuteVideo" toc="no"/>
             <topicref keyref="onUserOffline" toc="no"/>
-            <topicref keyref="onVideoDeviceStateChanged" toc="no"/>
             <topicref keyref="onVideoPublishStateChanged" toc="no"/>
             <topicref keyref="onVideoSizeChanged" toc="no"/>
             <topicref keyref="onVideoStopped" toc="no"/>
@@ -488,7 +480,6 @@
             <topicref keyref="ChannelMediaRelayConfiguration" toc="no"/>
             <topicref keyref="ClientRoleOptions" toc="no"/>
             <topicref keyref="DataStreamConfig" toc="no"/>
-            <topicref keyref="DownlinkNetworkInfo" toc="no"/>
             <topicref keyref="EncodedAudioFrameInfo" toc="no"/>
             <topicref keyref="EncodedVideoFrameInfo" toc="no"/>
             <topicref keyref="EncryptionConfig" toc="no"/>

--- a/dita/RTC/RTC_NG_API_iOS.ditamap
+++ b/dita/RTC/RTC_NG_API_iOS.ditamap
@@ -61,10 +61,10 @@
             <topicref keyref="getAudioMixingPlayoutVolume" toc="no"/>
             <topicref keyref="getAudioMixingPublishVolume" toc="no"/>
             <topicref keyref="getCallId" toc="no"/>
+            <topicref keyref="getCameraMaxZoomFactor" toc="no"/>
             <topicref keyref="getConnectionState" toc="no"/>
             <topicref keyref="getEffectsVolume" toc="no"/>
             <topicref keyref="getErrorDescription" toc="no"/>
-            <topicref keyref="getMediaEngineVersion" toc="no"/>
             <topicref keyref="getNativeHandle" toc="no"/>
             <topicref keyref="getVersion" toc="no"/>
             <topicref keyref="getUserInfoByUid" toc="no"/>
@@ -82,7 +82,6 @@
             <topicref keyref="joinChannelWithUserAccount2" toc="no"/>
             <topicref keyref="leaveChannel" toc="no"/>
             <topicref keyref="leaveChannel2" toc="no"/>
-            <topicref keyref="loadExtension" toc="no"/>
             <topicref keyref="muteAllRemoteAudioStreams" toc="no"/>
             <topicref keyref="muteAllRemoteVideoStreams" toc="no"/>
             <topicref keyref="muteLocalAudioStream" toc="no"/>
@@ -108,7 +107,6 @@
             <topicref keyref="registerAudioSpectrumObserver" toc="no"/>
             <topicref keyref="registerLocalUserAccount" toc="no"/>
             <topicref keyref="registerMediaMetadataObserver" toc="no"/>
-            <topicref keyref="registerMediaMetadataObserver" toc="no"/>
             <topicref keyref="registerVideoEncodedImageReceiver" toc="no"/>
             <topicref keyref="registerVideoFrameObserver" toc="no"/>
             <topicref keyref="resumeAllEffects" toc="no"/>
@@ -129,6 +127,7 @@
             <topicref keyref="setAudioEffectPreset" toc="no"/>
             <topicref keyref="setAudioMixingPosition" toc="no"/>
             <topicref keyref="setAudioProfile" toc="no"/>
+            <topicref keyref="setAudioProfile2"/>
             <topicref keyref="setCameraAutoFocusFaceModeEnabled" toc="no"/>
             <topicref keyref="setCameraCapturerConfiguration" toc="no"/>
             <topicref keyref="setCameraExposurePosition" toc="no"/>
@@ -200,7 +199,6 @@
             <topicref keyref="stopPreview" toc="no"/>
             <topicref keyref="stopScreenCapture" toc="no"/>
             <topicref keyref="switchCamera" toc="no"/>
-            <topicref keyref="updateChannelMediaOptions" toc="no"/>
             <topicref keyref="unregisterAudioSpectrumObserver" toc="no"/>
             <topicref keyref="unregisterMediaMetadataObserver" toc="no"/>
             <topicref keyref="updateChannelMediaOptions" toc="no"/>
@@ -234,8 +232,6 @@
         <topicref keyref="IRtcEngineEventHandler" chunk="to-content">
             <topicref keyref="onActiveSpeaker" toc="no"/>
             <topicref keyref="onApiCallExecuted" toc="no"/>
-            <topicref keyref="onAudioDeviceStateChanged" toc="no"/>
-            <topicref keyref="onAudioDeviceVolumeChanged" toc="no"/>
             <topicref keyref="onAudioEffectFinished" toc="no"/>
             <topicref keyref="onAudioMixingFinished" toc="no"/>
             <topicref keyref="onAudioMixingStateChanged" toc="no"/>
@@ -279,8 +275,6 @@
             <topicref keyref="onNetworkTypeChanged" toc="no"/>
             <topicref keyref="onPermissionError" toc="no"/>
             <topicref keyref="onRejoinChannelSuccess" toc="no"/>
-            <topicref keyref="onRemoteAudioMixingBegin" toc="no"/>
-            <topicref keyref="onRemoteAudioMixingEnd" toc="no"/>
             <topicref keyref="onRemoteAudioStateChanged" toc="no"/>
             <topicref keyref="onRemoteAudioStats" toc="no"/>
             <topicref keyref="onRemoteAudioTransportStats" toc="no"/>
@@ -305,7 +299,6 @@
             <topicref keyref="onUserJoined" toc="no"/>
             <topicref keyref="onUserMuteVideo" toc="no"/>
             <topicref keyref="onUserOffline" toc="no"/>
-            <topicref keyref="onVideoDeviceStateChanged" toc="no"/>
             <topicref keyref="onVideoPublishStateChanged" toc="no"/>
             <topicref keyref="onVideoSizeChanged" toc="no"/>
             <topicref keyref="onVideoStopped" toc="no"/>

--- a/dita/RTC/config/keys-rtc-ng-api-java.ditamap
+++ b/dita/RTC/config/keys-rtc-ng-api-java.ditamap
@@ -1420,13 +1420,6 @@
             </keydef>
         </topichead>
         <topichead navtitle="音频自采集">
-            <keydef keys="enableExternalAudioSourceLocalPlayback">
-                <topicmeta>
-                    <keywords>
-                        <keyword>enableExternalAudioSourceLocalPlayback</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
             <keydef keys="setExternalAudioSource" href="../API/api_setexternalaudiosource.dita">
                 <topicmeta>
                     <keywords>
@@ -2058,13 +2051,6 @@
                     </keywords>
                 </topicmeta>
             </keydef>
-            <keydef keys="onDownlinkNetworkInfoUpdated" href="../API/api_ondownlinknetworkinfoupdated.dita">
-                <topicmeta>
-                    <keywords>
-                        <keyword>onDownlinkNetworkInfoUpdated</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
         </topichead>
         <topichead navtitle="本地媒体事件">
             <keydef keys="onLocalAudioStateChanged" href="../API/api_onlocalaudiostatechanged.dita">
@@ -2317,20 +2303,6 @@
                 <topicmeta>
                     <keywords>
                         <keyword>onAudioEffectFinished</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
-            <keydef keys="onRemoteAudioMixingBegin" href="../API/api_onremoteaudiomixingbegin.dita">
-                <topicmeta>
-                    <keywords>
-                        <keyword>onRemoteAudioMixingBegin</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
-            <keydef keys="onRemoteAudioMixingEnd" href="../API/api_onremoteaudiomixingend.dita">
-                <topicmeta>
-                    <keywords>
-                        <keyword>onRemoteAudioMixingEnd</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -2609,29 +2581,6 @@
                 </topicmeta>
             </keydef>
         </topichead>
-        <topichead navtitle="设备管理事件">
-            <keydef keys="onAudioDeviceStateChanged" href="../API/api_onaudiodevicestatechanged.dita">
-                <topicmeta>
-                    <keywords>
-                        <keyword>onAudioDeviceStateChanged</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
-            <keydef keys="onAudioDeviceVolumeChanged" href="../API/api_onaudiodevicevolumechanged.dita">
-                <topicmeta>
-                    <keywords>
-                        <keyword>onAudioDeviceVolumeChanged</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
-            <keydef keys="onVideoDeviceStateChanged" href="../API/api_onvideodevicestatechanged.dita">
-                <topicmeta>
-                    <keywords>
-                        <keyword>onVideoDeviceStateChanged</keyword>
-                    </keywords>
-                </topicmeta>
-            </keydef>
-        </topichead>
         <topichead navtitle="流消息事件">
             <keydef keys="onStreamMessage" href="../API/api_onstreammessage.dita">
                 <topicmeta>
@@ -2768,13 +2717,6 @@
             <topicmeta>
                 <keywords>
                     <keyword>DataStreamConfig</keyword>
-                </keywords>
-            </topicmeta>
-        </keydef>
-        <keydef keys="DownlinkNetworkInfo" href="../API/class_downlinknetworkinfo.dita">
-            <topicmeta>
-                <keywords>
-                    <keyword>DownlinkNetworkInfo</keyword>
                 </keywords>
             </topicmeta>
         </keydef>


### PR DESCRIPTION
fixed following issues:
- [x] 点不到：enableExternalAudioSourceLocalPlayback, loadExtension, onDownlinkNetworkInfoUpdated
- [x] Java 有 map 无：getMediaEngineVersion, removeHandler, onLocalVideoStat
- [x] Java 无 map 有：onRemoteAudioMixingBegin, onRemoteAudioMixingEnd
- [x] Java/OC 有 map 无：pullAudioFrame, pullAudioFrame2, pushExternalAudioFrame1, pushExternalAudioFrame2, 
- [x] Android map 中有两个 registerMediaMetadataObserver、updateChanneMediaOptions
- [x] 缺 setAudioProfile，无 scenario 参数的那个方法
- [x] 缺 getCameraMaxZoomFactor
- [x] 没有 setHighQualityAudioParameters（没有文档）
- [x] Java/OC 无 map 有：onAudioDeviceStateChanged, onAudioDeviceVolumeChanged, onVideoDeviceStateChanged