### PR TITLE
Double Newline after Short

### DIFF
--- a/.github/workflows/python-app-4-all.yml
+++ b/.github/workflows/python-app-4-all.yml
@@ -33,11 +33,13 @@ jobs:
                 cd xml2json
                 echo "Running for ${{matrix.platform}} NG"
                 python xml2json.py --working_dir ../dita/RTC-NG --platform_tag ${{matrix.platform}} --json_file ${{matrix.platform}}_cn_ng.json --sdk_type rtc-ng --remove_sdk_type rtc --defined_path ${{matrix.platform}}-ng
+                python -mjson.tool "${{matrix.platform}}_cn_ng.json" > /dev/null
           - name: Run EN json creation
             run: |
                 cd xml2json
                 echo "Running for ${{matrix.platform}} NG"
                 python xml2json.py --working_dir ../en-US/dita/RTC-NG --platform_tag ${{matrix.platform}} --json_file ${{matrix.platform}}_en_ng.json --sdk_type rtc-ng --remove_sdk_type rtc --defined_path ${{matrix.platform}}-ng
+                python -mjson.tool "${{matrix.platform}}_en_ng.json" > /dev/null
           - name: Upload CN Artifact
             uses: actions/upload-artifact@v3
             with:

--- a/README.md
+++ b/README.md
@@ -1,33 +1,37 @@
 # 基于 DITA 的文档内容仓库（附带自动化 CI/CD）
 
-[![Awesome JSON CI build](https://github.com/AgoraDoc/doc_source/actions/workflows/python-app.yml/badge.svg)](https://github.com/AgoraDoc/doc_source/actions/workflows/python-app.yml)
-
-[![Awesome JSON CI build for NG Flutter SDK](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-ng-flutter.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-ng-flutter.yml)
-
-[![Awesome JSON CI build for NG RN SDK](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-3.8.200-kelu.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-3.8.200-kelu.yml)
-
-[![Awesome JSON CI build for NG Unity SDK](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-3.8.200-framework.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-3.8.200-framework.yml)
-
-[![Awesome JSON CI build for NG electron SDK](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-3.8.200-electron-yaxi.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-3.8.200-electron-yaxi.yml)
-
-[![Awesome prototype syncs](https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-sync-proto.yml/badge.svg)](https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-sync-proto.yml)
-
-[![Awesome DITA API doc prototype validation](https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-validate-prototype.yml/badge.svg)](https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-validate-prototype.yml)
-
-[![OxygenScript for DITA processing](https://github.com/AgoraDoc/doc_source/actions/workflows/OxygenScript.yml/badge.svg)](https://github.com/AgoraDoc/doc_source/actions/workflows/OxygenScript.yml)
-
-[![Awesome OxygenScript for DITA doc building (CG SDK)](https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding_CG.yml/badge.svg)](https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding_CG.yml)
-
-[![Awesome OxygenScript for DITA doc building (NG SDK)](https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding.yml/badge.svg)](https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding.yml)
-
-[![(NG SDK Frameworks)Awesome OxygenScript for DITA doc building](https://github.com/AgoraIO/agora_doc_source/actions/workflows/NG-SDK-Framework-Doc-Building.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/NG-SDK-Framework-Doc-Building.yml)
-
-[![Awesome automerge](https://github.com/AgoraIO/agora_doc_source/actions/workflows/automerge.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/automerge.yml)
-
-[![Awesome prototype from code to DITA (Electron)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-fetch-proto-electron.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-fetch-proto-electron.yml)
-
-[![Awesome script sync](https://github.com/AgoraIO/agora_doc_source/actions/workflows/sync-scripts-across-branches.yml/badge.svg)](https://github.com/AgoraIO/agora_doc_source/actions/workflows/sync-scripts-across-branches.yml)
-
+<p align="center">
+    <a href="https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-4-all.yml">
+        <img alt="4.x Json Docs" src="https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-4-all.yml/badge.svg" />
+    </a><br/>
+    <a href="https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-sync-proto.yml">
+        <img alt="Awesome prototype syncs" src="https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-sync-proto.yml/badge.svg" />
+    </a>
+    <a href="https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-validate-prototype.yml">
+        <img alt="Awesome DITA API doc prototype validation" src="https://github.com/AgoraDoc/doc_source/actions/workflows/python-app-validate-prototype.yml/badge.svg" />
+    </a>
+    <a href="https://github.com/AgoraDoc/doc_source/actions/workflows/OxygenScript.yml">
+        <img alt="OxygenScript for DITA processing" src="https://github.com/AgoraDoc/doc_source/actions/workflows/OxygenScript.yml/badge.svg" />
+    </a>
+    <a href="https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding_CG.ym">
+        <img alt="Awesome OxygenScript for DITA doc building (CG SDK)" src="https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding_CG.yml/badge.svg"/>
+    </a>
+    <a href="https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding.yml">
+        <img alt="Awesome OxygenScript for DITA doc building (NG SDK)" src="https://github.com/AgoraDoc/doc_source/actions/workflows/AwesomeOxygenScriptforDITADocBuilding.yml/badge.svg"/>
+    </a>
+    <a href="https://github.com/AgoraIO/agora_doc_source/actions/workflows/NG-SDK-Framework-Doc-Building.yml">
+        <img alt="(NG SDK Frameworks)Awesome OxygenScript for DITA doc building" src="https://github.com/AgoraIO/agora_doc_source/actions/workflows/NG-SDK-Framework-Doc-Building.yml/badge.svg"/>
+    </a>
+    <a href="https://github.com/AgoraIO/agora_doc_source/actions/workflows/automerge.yml">
+        <img alt="Awesome automerge" src="https://github.com/AgoraIO/agora_doc_source/actions/workflows/automerge.yml/badge.svg"/>
+    </a>
+    <a href="https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-fetch-proto-electron.yml">
+        <img alt="Awesome prototype from code to DITA (Electron)" src="https://github.com/AgoraIO/agora_doc_source/actions/workflows/python-app-fetch-proto-electron.yml/badge.svg" />
+    </a>
+    <a href="https://github.com/AgoraIO/agora_doc_source/actions/workflows/sync-scripts-across-branches.yml">
+        <img alt="Awesome script sync" src="https://github.com/AgoraIO/agora_doc_source/actions/workflows/sync-scripts-across-branches.yml/badge.svg"/>
+    </a>
+</p>
 <!-- TOC -->
 
 - [基于 DITA 的文档内容仓库](#基于-dita-的文档内容仓库)

--- a/xml2json/xml2json.py
+++ b/xml2json/xml2json.py
@@ -1042,7 +1042,7 @@ def create_json_from_xml(working_dir, file_dir, android_path, cpp_path, rust_pat
     if short_desc is not None:
         for text in short_desc.itertext():
             # Add "\n" to add a line break after short desc
-            short_desc_text = short_desc_text.strip("\n") + text.strip("\n") + "\n\n"
+            short_desc_text = short_desc_text.strip("\n") + text.strip("\n") + "<!DOUBLE_BREAK!>"
 
     if short_desc is None:
         # short_desc = "Empty"
@@ -1270,6 +1270,7 @@ def replace_newline():
     replaced_file_text = re.sub(r'For more details[A-Za-z\s\\n,]{0,50}\.', '', replaced_file_text)
     replaced_file_text = re.sub(r'For details[A-Za-z\s\\n,]{0,50}\.', '', replaced_file_text)
     replaced_file_text = re.sub(r':[\s]{0,10}"\\n[\s\\n]{0,50}', ':"', replaced_file_text)
+    replaced_file_text = replaced_file_text.replace("<!DOUBLE_BREAK!>", "\\n\\n")
 
     # ------------------ Special processing for Flutter classes ------------------------------------------
     replaced_file_text = re.sub('class_rtc_render_view_rtcsurfaceview', 'class_rtcsurfaceview', replaced_file_text)

--- a/xml2json/xml2json.py
+++ b/xml2json/xml2json.py
@@ -1042,7 +1042,7 @@ def create_json_from_xml(working_dir, file_dir, android_path, cpp_path, rust_pat
     if short_desc is not None:
         for text in short_desc.itertext():
             # Add "\n" to add a line break after short desc
-            short_desc_text = short_desc_text.strip("\n") + text.strip("\n") + "\n"
+            short_desc_text = short_desc_text.strip("\n") + text.strip("\n") + "\n\n"
 
     if short_desc is None:
         # short_desc = "Empty"


### PR DESCRIPTION
Adding a double newline after the short description, instead of a single newline.

To do this, I had to add a specific string that gets replaced later, as there are multiple newline removers at the point where all the files are getting merged.

Also updated the badges in the README with new URLs and an updated format.