### PR TITLE
push releases to branch-build

### DIFF
--- a/.github/workflows/AwesomeOxygenScriptforDITADocBuilding.yml
+++ b/.github/workflows/AwesomeOxygenScriptforDITADocBuilding.yml
@@ -118,89 +118,89 @@ jobs:
                 name: mac_ng_en_doc.zip
             - name: Upload C++ NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/cpp_ng_cn_doc.zip
                   asset_name: cpp_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload C++ NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/cpp_ng_en_doc.zip
                   asset_name: cpp_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Android NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/android_ng_cn_doc.zip
                   asset_name: android_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Android NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/android_ng_en_doc.zip
                   asset_name: android_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload iOS NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/ios_ng_cn_doc.zip
                   asset_name: ios_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload iOS NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/ios_ng_en_doc.zip
                   asset_name: ios_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload macOS NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/mac_ng_cn_doc.zip
                   asset_name: mac_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload macOS NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/mac_ng_en_doc.zip
                   asset_name: mac_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."

--- a/.github/workflows/AwesomeOxygenScriptforDITADocBuilding_CG.yml
+++ b/.github/workflows/AwesomeOxygenScriptforDITADocBuilding_CG.yml
@@ -87,48 +87,48 @@ jobs:
     
     - name: Upload Flutter CG CN doc Artifact
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dita/RTC/out/flutter_cg_cn_doc.zip
           asset_name: flutter_cg_cn_doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."
         
     - name: Upload CSharp CG CN doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dita/RTC/out/cs_cg_cn_doc.zip
           asset_name: cs_cg_cn_doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."
     
     - name: Upload Flutter CG EN doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: en-US/dita/RTC/out/flutter_cg_en_doc.zip
           asset_name: flutter_cg_en_doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."
     
     - name: Upload CSharp CG EN doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: en-US/dita/RTC/out/cs_cg_en_doc.zip
           asset_name: cs_cg_en_doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."          

--- a/.github/workflows/NG-SDK-Framework-Doc-Building.yml
+++ b/.github/workflows/NG-SDK-Framework-Doc-Building.yml
@@ -119,89 +119,89 @@ jobs:
                 name: electron_ng_en_doc.zip
             - name: Upload Flutter NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/flutter_ng_cn_doc.zip
                   asset_name: flutter_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Flutter NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/flutter_ng_en_doc.zip
                   asset_name: flutter_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload RN NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/rn_ng_cn_doc.zip
                   asset_name: rn_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload RN NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/rn_ng_en_doc.zip
                   asset_name: rn_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Unity NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/unity_ng_cn_doc.zip
                   asset_name: unity_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Unity NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/unity_ng_en_doc.zip
                   asset_name: unity_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Electron NG CN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: dita/RTC-NG/out/electron_ng_cn_doc.zip
                   asset_name: electron_ng_cn_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."
             - name: Upload Electron NG EN doc to release
               if: github.ref_name == github.event.repository.default_branch
-              uses: svenstaro/upload-release-action@2.5.0
+              uses: svenstaro/upload-release-action@2.6.0
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   file: en-US/dita/RTC-NG/out/electron_ng_en_doc.zip
                   asset_name: electron_ng_en_doc.zip
-                  tag: ${{ steps.branch-name.outputs.current_branch }}
+                  tag: ${{ steps.branch-name.outputs.current_branch }}-build
                   make_latest: false
                   overwrite: true
                   body: "DITA docs."

--- a/.github/workflows/python-app-4-all.yml
+++ b/.github/workflows/python-app-4-all.yml
@@ -52,22 +52,22 @@ jobs:
               path: xml2json/${{matrix.platform}}_en_ng.json
           - name: Upload ${{matrix.platform}} NG CN JSON to release
             if: github.ref_name == github.event.repository.default_branch
-            uses: svenstaro/upload-release-action@2.5.0
+            uses: svenstaro/upload-release-action@2.6.0
             with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: xml2json/${{matrix.platform}}_cn_ng.json
                 asset_name: ${{matrix.platform}}_ng_json_template_cn.json
-                tag: ${{ steps.branch-name.outputs.current_branch }}
+                tag: ${{ steps.branch-name.outputs.current_branch }}-build
                 overwrite: true
                 body: "Template file for automatic comment population."
           - name: Upload ${{matrix.platform}} NG EN JSON to release
             if: github.ref_name == github.event.repository.default_branch
-            uses: svenstaro/upload-release-action@2.5.0
+            uses: svenstaro/upload-release-action@2.6.0
             with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: xml2json/${{matrix.platform}}_en_ng.json
                 asset_name: ${{matrix.platform}}_ng_json_template_en.json
-                tag: ${{ steps.branch-name.outputs.current_branch }}
+                tag: ${{ steps.branch-name.outputs.current_branch }}-build
                 overwrite: true
                 body: "Template file for automatic comment population."
       

--- a/.github/workflows/python-app-fc.yml
+++ b/.github/workflows/python-app-fc.yml
@@ -88,45 +88,45 @@ jobs:
           name: fc-ios-cn-doc.zip
     - name: Upload FC EN Android doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: en-US/dita/flexible-classroom/edu-context/out/fc-android-en-doc.zip
           asset_name: fc-android-en-doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."
     - name: Upload FC EN iOS doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: en-US/dita/flexible-classroom/edu-context/out/fc-ios-en-doc.zip
           asset_name: fc-ios-en-doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."
     - name: Upload FC CN Android doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dita/flexible-classroom/edu-context/out/fc-android-cn-doc.zip
           asset_name: fc-android-cn-doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."
     - name: Upload FC CN iOS doc to release
       if: github.ref_name == github.event.repository.default_branch
-      uses: svenstaro/upload-release-action@2.5.0
+      uses: svenstaro/upload-release-action@2.6.0
       with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dita/flexible-classroom/edu-context/out/fc-ios-cn-doc.zip
           asset_name: fc-ios-cn-doc.zip
-          tag: ${{ steps.branch-name.outputs.current_branch }}
+          tag: ${{ steps.branch-name.outputs.current_branch }}-build
           make_latest: false
           overwrite: true
           body: "DITA docs."

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ def main():
 
 ## 从 API 文档自动构建用于自动化填充代码注释的文档模板
 
-文档模板文件（JSON 文件）会在 https://github.com/AgoraIO/agora_doc_source/releases/tag/main 自动生成。SDK 研发可以通过脚本自动抓取。
+文档模板文件（JSON 文件）会在 https://github.com/AgoraIO/agora_doc_source/releases/tag/master-build 自动生成。SDK 研发可以通过脚本自动抓取。
 
 如果你需要为某分支生成 JSON 文件，你需要在以下文件中添加你的分支：
 


### PR DESCRIPTION
@Cilla-luodan crisis over! builds will be sent to `master-build`, instead of `main` or `master`.