### PR TITLE
Added Ditamap Aliases

### DIFF
--- a/dita/RTC-NG/config/keys-rtc-ng-api-ios.ditamap
+++ b/dita/RTC-NG/config/keys-rtc-ng-api-ios.ditamap
@@ -66,6 +66,13 @@
                 </keywords>
             </topicmeta>
         </keydef>
+        <keydef keys="IMediaEngine" href="../API/class_imediaengine.dita" props="hide">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraRtcEngineKit</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
         <keydef keys="IRtcEngineEx" href="../API/class_irtcengineex.dita">
             <topicmeta>
                 <keywords>
@@ -88,6 +95,13 @@
             </topicmeta>
         </keydef>
         <keydef keys="IAudioFrameObserver" href="../API/class_iaudioframeobserver.dita">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraAudioFrameDelegate</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
+        <keydef keys="IAudioFrameObserverBase" href="../API/class_iaudioframeobserverbase.dita" props="hide">
             <topicmeta>
                 <keywords>
                     <keyword>AgoraAudioFrameDelegate</keyword>
@@ -359,14 +373,14 @@
             <keydef keys="getUserInfoByUid" href="../API/api_irtcengine_getuserinfobyuid.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUid</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccount" href="../API/api_irtcengine_getuserinfobyuseraccount.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccount</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1183,14 +1197,14 @@
             <keydef keys="getUserInfoByUidEx" href="../API/api_irtcengineex_getuserinfobyuidex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUidEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccountEx" href="../API/api_irtcengineex_getuserinfobyuseraccountex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccountEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1433,13 +1447,20 @@
                 </keywords>
             </topicmeta>
         </keydef>
+        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita" props="hide">
+            <topicmeta>
+                <keywords>
+                    <keyword>muteRecordingSignalEx</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
         <keydef keys="stopChannelMediaRelayEx" href="../API/api_irtcengineex_stopchannelmediarelayex.dita">
             <topicmeta>
                 <keywords>
                     <keyword>StopChannelMediaRelayEx</keyword>
                 </keywords>
-</topicmeta>
-</keydef>
+            </topicmeta>
+        </keydef>
     </topichead>
         <topichead navtitle="音乐文件播放及混音">
             <keydef keys="setAudioMixingDualMonoMode" href="../API/api_irtcengine_setaudiomixingdualmonomode.dita">
@@ -2839,7 +2860,7 @@
             <keydef keys="getCameraMaxZoomFactor" href="../API/api_irtcengine_getcameramaxzoomfactor.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getCameraMaxZoomFactor</keyword>
+                        <keyword>cameraMaxZoomFactor</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>

--- a/dita/RTC-NG/config/keys-rtc-ng-api-macos.ditamap
+++ b/dita/RTC-NG/config/keys-rtc-ng-api-macos.ditamap
@@ -45,6 +45,13 @@
                 </keywords>
             </topicmeta>
         </keydef>
+        <keydef keys="IMediaEngine" href="../API/class_imediaengine.dita" props="hide">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraRtcEngineKit</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
         <keydef keys="IRtcEngineEx" href="../API/class_irtcengineex.dita">
             <topicmeta>
                 <keywords>
@@ -67,6 +74,13 @@
             </topicmeta>
         </keydef>
         <keydef keys="IAudioFrameObserver" href="../API/class_iaudioframeobserver.dita">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraAudioFrameDelegate</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
+        <keydef keys="IAudioFrameObserverBase" href="../API/class_iaudioframeobserverbase.dita" props="hide">
             <topicmeta>
                 <keywords>
                     <keyword>AgoraAudioFrameDelegate</keyword>
@@ -317,14 +331,14 @@
             <keydef keys="getUserInfoByUid" href="../API/api_irtcengine_getuserinfobyuid.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUid</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccount" href="../API/api_irtcengine_getuserinfobyuseraccount.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccount</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1141,14 +1155,14 @@
             <keydef keys="getUserInfoByUidEx" href="../API/api_irtcengineex_getuserinfobyuidex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUidEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccountEx" href="../API/api_irtcengineex_getuserinfobyuseraccountex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccountEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1388,6 +1402,13 @@
             <topicmeta>
                 <keywords>
                     <keyword>muteAllRemoteVideoStreamsEx</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
+        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita" props="hide">
+            <topicmeta>
+                <keywords>
+                    <keyword>muteRecordingSignalEx</keyword>
                 </keywords>
             </topicmeta>
         </keydef>

--- a/en-US/dita/RTC-NG/config/keys-rtc-ng-api-ios.ditamap
+++ b/en-US/dita/RTC-NG/config/keys-rtc-ng-api-ios.ditamap
@@ -1447,7 +1447,7 @@
                 </keywords>
             </topicmeta>
         </keydef>
-        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita">
+        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita" props="hide">
             <topicmeta>
                 <keywords>
                     <keyword>muteRecordingSignalEx</keyword>

--- a/en-US/dita/RTC-NG/config/keys-rtc-ng-api-ios.ditamap
+++ b/en-US/dita/RTC-NG/config/keys-rtc-ng-api-ios.ditamap
@@ -66,6 +66,13 @@
                 </keywords>
             </topicmeta>
         </keydef>
+        <keydef keys="IMediaEngine" href="../API/class_imediaengine.dita" props="hide">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraRtcEngineKit</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
         <keydef keys="IRtcEngineEx" href="../API/class_irtcengineex.dita">
             <topicmeta>
                 <keywords>
@@ -88,6 +95,13 @@
             </topicmeta>
         </keydef>
         <keydef keys="IAudioFrameObserver" href="../API/class_iaudioframeobserver.dita">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraAudioFrameDelegate</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
+        <keydef keys="IAudioFrameObserverBase" href="../API/class_iaudioframeobserverbase.dita" props="hide">
             <topicmeta>
                 <keywords>
                     <keyword>AgoraAudioFrameDelegate</keyword>
@@ -359,14 +373,14 @@
             <keydef keys="getUserInfoByUid" href="../API/api_irtcengine_getuserinfobyuid.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUid</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccount" href="../API/api_irtcengine_getuserinfobyuseraccount.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccount</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1183,14 +1197,14 @@
             <keydef keys="getUserInfoByUidEx" href="../API/api_irtcengineex_getuserinfobyuidex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUidEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccountEx" href="../API/api_irtcengineex_getuserinfobyuseraccountex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccountEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1433,13 +1447,20 @@
                 </keywords>
             </topicmeta>
         </keydef>
+        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita">
+            <topicmeta>
+                <keywords>
+                    <keyword>muteRecordingSignalEx</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
         <keydef keys="stopChannelMediaRelayEx" href="../API/api_irtcengineex_stopchannelmediarelayex.dita">
             <topicmeta>
                 <keywords>
                     <keyword>StopChannelMediaRelayEx</keyword>
                 </keywords>
-</topicmeta>
-</keydef>
+            </topicmeta>
+        </keydef>
     </topichead>
         <topichead navtitle="音乐文件播放及混音">
             <keydef keys="setAudioMixingDualMonoMode" href="../API/api_irtcengine_setaudiomixingdualmonomode.dita">
@@ -2839,7 +2860,7 @@
             <keydef keys="getCameraMaxZoomFactor" href="../API/api_irtcengine_getcameramaxzoomfactor.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getCameraMaxZoomFactor</keyword>
+                        <keyword>cameraMaxZoomFactor</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>

--- a/en-US/dita/RTC-NG/config/keys-rtc-ng-api-macos.ditamap
+++ b/en-US/dita/RTC-NG/config/keys-rtc-ng-api-macos.ditamap
@@ -1405,7 +1405,7 @@
                 </keywords>
             </topicmeta>
         </keydef>
-        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita">
+        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita" props="hide">
             <topicmeta>
                 <keywords>
                     <keyword>muteRecordingSignalEx</keyword>

--- a/en-US/dita/RTC-NG/config/keys-rtc-ng-api-macos.ditamap
+++ b/en-US/dita/RTC-NG/config/keys-rtc-ng-api-macos.ditamap
@@ -45,6 +45,13 @@
                 </keywords>
             </topicmeta>
         </keydef>
+        <keydef keys="IMediaEngine" href="../API/class_imediaengine.dita" props="hide">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraRtcEngineKit</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
         <keydef keys="IRtcEngineEx" href="../API/class_irtcengineex.dita">
             <topicmeta>
                 <keywords>
@@ -67,6 +74,13 @@
             </topicmeta>
         </keydef>
         <keydef keys="IAudioFrameObserver" href="../API/class_iaudioframeobserver.dita">
+            <topicmeta>
+                <keywords>
+                    <keyword>AgoraAudioFrameDelegate</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
+        <keydef keys="IAudioFrameObserverBase" href="../API/class_iaudioframeobserverbase.dita" props="hide">
             <topicmeta>
                 <keywords>
                     <keyword>AgoraAudioFrameDelegate</keyword>
@@ -317,14 +331,14 @@
             <keydef keys="getUserInfoByUid" href="../API/api_irtcengine_getuserinfobyuid.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUid</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccount" href="../API/api_irtcengine_getuserinfobyuseraccount.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccount</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1141,14 +1155,14 @@
             <keydef keys="getUserInfoByUidEx" href="../API/api_irtcengineex_getuserinfobyuidex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserId</keyword>
+                        <keyword>getUserInfoByUidEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
             <keydef keys="getUserInfoByUserAccountEx" href="../API/api_irtcengineex_getuserinfobyuseraccountex.dita">
                 <topicmeta>
                     <keywords>
-                        <keyword>getUserInfoWithUserAccount</keyword>
+                        <keyword>getUserInfoByUserAccountEx</keyword>
                     </keywords>
                 </topicmeta>
             </keydef>
@@ -1388,6 +1402,13 @@
             <topicmeta>
                 <keywords>
                     <keyword>muteAllRemoteVideoStreamsEx</keyword>
+                </keywords>
+            </topicmeta>
+        </keydef>
+        <keydef keys="muteRecordingSignalEx" href="../API/api_irtcengineex_muterecordingsignalex.dita">
+            <topicmeta>
+                <keywords>
+                    <keyword>muteRecordingSignalEx</keyword>
                 </keywords>
             </topicmeta>
         </keydef>


### PR DESCRIPTION
Some of the classes are not used directly with the iOS or macOS SDK, such as IMediaEngine.

The functions inside IMediaEngine are instead directly accessible from IRtcEngine. Therefore to export the JSON correctly for comment injection, we must add this to the ditamaps as hidden properties.