### PR TITLE
RN/Electron: fix publish error

### DIFF
--- a/dita/RTC-NG/API/api_irtcengine_setcameradeviceorientation.dita
+++ b/dita/RTC-NG/API/api_irtcengine_setcameradeviceorientation.dita
@@ -34,7 +34,7 @@
             <title>详情</title>
             <note type="attention"><ul>
             <li props="cpp unreal bp electron unity flutter">该方法仅适用于 Windows。</li>
-            <li conkeyref="setCameraExposureFactor/sequence" />
+            <li>该方法必须在 <xref keyref="enableVideo"/> 后调用，设置结果在摄像头成功开启后生效，即 SDK 触发 <xref keyref="onLocalVideoStateChanged" /> 回调返回本地视频状态为 <apiname keyref="LOCAL_VIDEO_STREAM_STATE_CAPTURING"/> (1) 后。</li>
             <li>当视频采集设备不带重力感应功能时，你可以调用该方法手动调整采集到的视频画面的旋转角度。</li>
             </ul></note>
         </section>

--- a/dita/RTC-NG/API/api_irtcengine_setcameradeviceorientation.dita
+++ b/dita/RTC-NG/API/api_irtcengine_setcameradeviceorientation.dita
@@ -34,7 +34,7 @@
             <title>详情</title>
             <note type="attention"><ul>
             <li props="cpp unreal bp electron unity flutter">该方法仅适用于 Windows。</li>
-            <li>该方法必须在 <xref keyref="enableVideo"/> 后调用，设置结果在摄像头成功开启后生效，即 SDK 触发 <xref keyref="onLocalVideoStateChanged" /> 回调返回本地视频状态为 <apiname keyref="LOCAL_VIDEO_STREAM_STATE_CAPTURING"/> (1) 后。</li>
+            <li conkeyref="setCameraExposureFactor/sequence" />
             <li>当视频采集设备不带重力感应功能时，你可以调用该方法手动调整采集到的视频画面的旋转角度。</li>
             </ul></note>
         </section>

--- a/dita/RTC-NG/API/api_irtcengine_startpreview2.dita
+++ b/dita/RTC-NG/API/api_irtcengine_startpreview2.dita
@@ -38,7 +38,7 @@
             <ul>
             <li>本地预览默认开启镜像功能。</li>
             <li>如果调用 <xref keyref="leaveChannel2" />退出频道，本地预览依然处于开启状态，如需要关闭本地预览，需要调用 <xref keyref="stopPreview2" />。</li>
-            <li>该方法中设置的视频源类型需要跟 <xref keyref="setupLocalVideo" /> 中 <xref keyref="VideoCanvas" /> 的视频源类型一致。</li>
+            <li props="native unity cs electron flutter unreal bp">该方法中设置的视频源类型需要跟 <xref keyref="setupLocalVideo" /> 中 <xref keyref="VideoCanvas" /> 的视频源类型一致。</li>
             </ul> </note> </section>
         <section id="parameters">
             <title>参数</title>

--- a/dita/RTC-NG/API/api_irtcengine_startpreview2.dita
+++ b/dita/RTC-NG/API/api_irtcengine_startpreview2.dita
@@ -38,7 +38,7 @@
             <ul>
             <li>本地预览默认开启镜像功能。</li>
             <li>如果调用 <xref keyref="leaveChannel2" />退出频道，本地预览依然处于开启状态，如需要关闭本地预览，需要调用 <xref keyref="stopPreview2" />。</li>
-            <li props="native unity cs electron flutter unreal bp">该方法中设置的视频源类型需要跟 <xref keyref="setupLocalVideo" /> 中 <xref keyref="VideoCanvas" /> 的视频源类型一致。</li>
+            <li>该方法中设置的视频源类型需要跟 <xref keyref="setupLocalVideo" /> 中 <xref keyref="VideoCanvas" /> 的视频源类型一致。</li>
             </ul> </note> </section>
         <section id="parameters">
             <title>参数</title>


### PR DESCRIPTION
1. startPreview2 中的 note 引用到了 `setupLocalVideo`，RN 不支持，所以 props 排除了 RN
2. setcameradeviceorientation 中的 conkeyref 引用了 setCameraExposureFactor，Electron ditamap 里没有，所以恢复成了文字