### PR TITLE
docs: update FlutterTexture platform note

### DIFF
--- a/dita/RTC-AIDOC-FRAMEWORK/API/api_videoviewcontroller_videoviewcontrollerconstructor.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/api_videoviewcontroller_videoviewcontrollerconstructor.dita
@@ -36,7 +36,7 @@
                 <plentry props="flutter">
                     <pt>useFlutterTexture</pt>
                     <pd>
-                        <note><codeph>FlutterTexture</codeph> 仅适用于 iOS、macOS 和 Windows 平台。</note><ph>是否使用 <codeph>FlutterTexture</codeph> 渲染视频：</ph>
+                        <note><codeph>FlutterTexture</codeph> 适用于 Android、iOS、macOS 和 Windows 平台。</note><ph>是否使用 <codeph>FlutterTexture</codeph> 渲染视频：</ph>
                         <ul>
                             <li><xref keyref="true"/>: 使用 <codeph>FlutterTexture</codeph> 渲染视频。</li>
                             <li><xref keyref="false"/>: 不使用  <codeph>FlutterTexture</codeph> 渲染视频。</li>

--- a/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontroller.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontroller.dita
@@ -76,7 +76,7 @@
                 <plentry props="flutter">
                     <pt>useFlutterTexture</pt>
                     <pd>
-                        <note><codeph>FlutterTexture</codeph> 仅适用于 iOS、macOS 和 Windows 平台。</note><ph>是否使用 <codeph>FlutterTexture</codeph> 渲染视频：</ph>
+                        <note><codeph>FlutterTexture</codeph> 适用于 Android、iOS、macOS 和 Windows 平台。</note><ph>是否使用 <codeph>FlutterTexture</codeph> 渲染视频：</ph>
                         <ul>
                             <li><xref keyref="true"/>: 使用 <codeph>FlutterTexture</codeph> 渲染视频。</li>
                             <li><xref keyref="false"/>: 不使用  <codeph>FlutterTexture</codeph> 渲染视频。</li>

--- a/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontrollerbase.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontrollerbase.dita
@@ -43,7 +43,7 @@
                 <plentry props="flutter">
                     <pt>useFlutterTexture</pt>
                     <pd>
-                        <note><codeph>FlutterTexture</codeph> 仅适用于 iOS、macOS 和 Windows 平台。</note><ph>是否使用 <codeph>FlutterTexture</codeph> 渲染视频：</ph>
+                        <note><codeph>FlutterTexture</codeph> 适用于 Android、iOS、macOS 和 Windows 平台。</note><ph>是否使用 <codeph>FlutterTexture</codeph> 渲染视频：</ph>
                         <ul>
                             <li><xref keyref="true"/>: 使用 <codeph>FlutterTexture</codeph> 渲染视频。</li>
                             <li><xref keyref="false"/>: 不使用  <codeph>FlutterTexture</codeph> 渲染视频。</li>

--- a/en-US/dita/RTC-AIDOC-FRAMEWORK/API/api_videoviewcontroller_videoviewcontrollerconstructor.dita
+++ b/en-US/dita/RTC-AIDOC-FRAMEWORK/API/api_videoviewcontroller_videoviewcontrollerconstructor.dita
@@ -36,7 +36,7 @@
                 <plentry props="flutter">
                     <pt>useFlutterTexture</pt>
                     <pd>
-                        <note><codeph>FlutterTexture</codeph> is only applicable to iOS, macOS, and Windows platforms.</note><ph>Whether to use <codeph>FlutterTexture</codeph> to render video:</ph>
+                        <note><codeph>FlutterTexture</codeph> applies to Android, iOS, macOS, and Windows platforms.</note><ph>Whether to use <codeph>FlutterTexture</codeph> to render video:</ph>
                         <ul>
                             <li><xref keyref="true"/>: Use <codeph>FlutterTexture</codeph> to render video.</li>
                             <li><xref keyref="false"/>: Do not use <codeph>FlutterTexture</codeph> to render video.</li>

--- a/en-US/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontroller.dita
+++ b/en-US/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontroller.dita
@@ -76,7 +76,7 @@
                 <plentry props="flutter">
                     <pt>useFlutterTexture</pt>
                     <pd>
-                        <note><codeph>FlutterTexture</codeph> is only available on iOS, macOS, and Windows platforms.</note><ph>Whether to use <codeph>FlutterTexture</codeph> to render video:</ph>
+                        <note><codeph>FlutterTexture</codeph> applies to Android, iOS, macOS, and Windows platforms.</note><ph>Whether to use <codeph>FlutterTexture</codeph> to render video:</ph>
                         <ul>
                             <li><xref keyref="true"/>: Use <codeph>FlutterTexture</codeph> to render video.</li>
                             <li><xref keyref="false"/>: Do not use <codeph>FlutterTexture</codeph> to render video.</li>

--- a/en-US/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontrollerbase.dita
+++ b/en-US/dita/RTC-AIDOC-FRAMEWORK/API/class_videoviewcontrollerbase.dita
@@ -43,7 +43,7 @@
                 <plentry props="flutter">
                     <pt>useFlutterTexture</pt>
                     <pd>
-                        <note><codeph>FlutterTexture</codeph> is only available on iOS, macOS, and Windows platforms.</note><ph>Whether to use <codeph>FlutterTexture</codeph> to render video:</ph>
+                        <note><codeph>FlutterTexture</codeph> applies to Android, iOS, macOS, and Windows platforms.</note><ph>Whether to use <codeph>FlutterTexture</codeph> to render video:</ph>
                         <ul>
                             <li><xref keyref="true"/>: Use <codeph>FlutterTexture</codeph> to render video.</li>
                             <li><xref keyref="false"/>: Do not use <codeph>FlutterTexture</codeph> to render video.</li>


### PR DESCRIPTION
## Summary
- Update RTC Flutter VideoViewController `useFlutterTexture` notes to include Android.
- Sync the same change in zh-CN and en-US DITA sources for VideoViewController, VideoViewControllerBase, and the constructor API page.
- This corresponds to the already merged shengwang-doc-source HTML PR: https://github.com/AgoraIO/shengwang-doc-source/pull/2026

## Validation
- `xmllint --noout` on all 6 edited DITA files
- `git diff --check`
- Regenerated zh-CN target DITA to /tmp and verified the 3 target notes include Android
- Regenerated en-US target DITA to /tmp and verified the 3 target notes include Android