### PR TITLE
docs: update SnapshotConfig position constraints (DF-011)

### DIFF
--- a/dita/RTC-AIDOC/API/class_snapshotconfig.dita
+++ b/dita/RTC-AIDOC/API/class_snapshotconfig.dita
@@ -41,7 +41,12 @@
                 </plentry>
                 <plentry props="cpp">
                     <pt>position</pt>
-                    <pd>截图视频帧在视频处理流程中的位置，详见 <xref keyref="VIDEO_MODULE_POSITION"/>。</pd>
+                    <pd>截图视频帧在视频处理流程中的位置，详见 <xref keyref="VIDEO_MODULE_POSITION"/>。具体取值取决于调用 <codeph>takeSnapshot</codeph> 或 <codeph>takeSnapshotEx</codeph> 时传入的 <codeph>uid</codeph>：
+                        <ul>
+                            <li><codeph>uid</codeph> 为 <codeph>0</codeph>：<codeph>position</codeph> 支持 <codeph>2</codeph>、<codeph>4</codeph> 和 <codeph>8</codeph>。</li>
+                            <li><codeph>uid</codeph> 不为 <codeph>0</codeph>：<codeph>position</codeph> 仅支持 <codeph>2</codeph>。</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="ios">
                     <pt>filePath</pt>
@@ -61,7 +66,12 @@
                 </plentry>
                 <plentry props="android">
                     <pt>position</pt>
-                    <pd>截图视频帧在视频处理链中的位置，详见 <xref keyref="VIDEO_MODULE_POSITION"/>。</pd>
+                    <pd>截图视频帧在视频处理链中的位置，详见 <xref keyref="VIDEO_MODULE_POSITION"/>。具体取值取决于调用 <codeph>takeSnapshot</codeph> 或 <codeph>takeSnapshotEx</codeph> 时传入的 <codeph>uid</codeph>：
+                        <ul>
+                            <li><codeph>uid</codeph> 为 <codeph>0</codeph>：<codeph>position</codeph> 支持 <codeph>2</codeph>、<codeph>4</codeph> 和 <codeph>8</codeph>。</li>
+                            <li><codeph>uid</codeph> 不为 <codeph>0</codeph>：<codeph>position</codeph> 仅支持 <codeph>2</codeph>。</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="mac">
                     <pt>filePath</pt>

--- a/en-US/dita/RTC-AIDOC/API/class_snapshotconfig.dita
+++ b/en-US/dita/RTC-AIDOC/API/class_snapshotconfig.dita
@@ -33,7 +33,12 @@
                 </plentry>
                 <plentry props="cpp">
                     <pt>position</pt>
-                    <pd>Position of the video frame in the video processing pipeline where the screenshot is taken. See <xref keyref="VIDEO_MODULE_POSITION"/>.</pd>
+                    <pd>The position of the video observation. See <xref keyref="VIDEO_MODULE_POSITION"/>. Allowed values vary depending on the <codeph>uid</codeph> parameter passed in <codeph>takeSnapshot</codeph> or <codeph>takeSnapshotEx</codeph>:
+                        <ul>
+                            <li><codeph>uid</codeph> = 0: Position 2, 4 and 8 are allowed.</li>
+                            <li><codeph>uid</codeph> != 0: Only position 2 is allowed.</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="android">
                     <pt>filePath</pt>
@@ -43,7 +48,12 @@
                 </plentry>
                 <plentry props="android">
                     <pt>position</pt>
-                    <pd>The position of the video frame to snapshot in the video processing pipeline. See <xref keyref="VIDEO_MODULE_POSITION"/>.</pd>
+                    <pd>The position of the video observation. See <xref keyref="VIDEO_MODULE_POSITION"/>. Allowed values vary depending on the <codeph>uid</codeph> parameter passed in <codeph>takeSnapshot</codeph> or <codeph>takeSnapshotEx</codeph>:
+                        <ul>
+                            <li><codeph>uid</codeph> = 0: Position 2, 4 and 8 are allowed.</li>
+                            <li><codeph>uid</codeph> != 0: Only position 2 is allowed.</li>
+                        </ul>
+                    </pd>
                 </plentry>
             </parml>
         </section>


### PR DESCRIPTION
## Summary

- regenerate the Chinese and English `SnapshotConfig` DITA topics
- document the supported `position` values for local and remote snapshot UIDs
- keep the change limited to Android and C++ conditional content

## Source

- SDK branch: `jira/DOC-4842/restore-snapshotconfig-position`
- structured data branch: `codex/df-011-snapshotconfig-doc-data`
- published HTML PR: https://github.com/AgoraIO/shengwang-doc-source/pull/2054
- review: `df-011-prepare-20260729`

## Validation

- Chinese and English JSON parse completed
- `xmllint --noout` passed for both modified DITA files
- Android Oxygen transformation completed successfully
- C++ Oxygen transformation completed with `BUILD SUCCESSFUL`
