### PR TITLE
[DF-012] Update renew token callback DITA

### DIFF
--- a/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_onrequesttoken.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_onrequesttoken.dita
@@ -21,48 +21,48 @@
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
             <p props="electron">在音视频互动过程中，如果 Token 失效，SDK 会触发该回调报告 Token 已过期。
-当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
             <p props="rn">在音视频互动过程中，如果 Token 失效，SDK 会触发该回调报告 Token 已过期。
-当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
             <p props="flutter">在音视频互动过程中，如果 Token 失效，SDK 会触发该回调报告 Token 已过期。
-当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
             <p props="unity">在音视频互动过程中，如果 Token 失效，SDK 会触发该回调报告 Token 已过期。
-当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>

--- a/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_ontokenprivilegewillexpire.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_ontokenprivilegewillexpire.dita
@@ -21,45 +21,45 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <p props="electron">当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+            <p props="electron">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
-            <p props="rn">当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+            <p props="rn">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
-            <p props="flutter">当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+            <p props="flutter">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
-            <p props="unity">当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+            <p props="unity">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>

--- a/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_onrequesttoken.dita
+++ b/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_onrequesttoken.dita
@@ -20,15 +20,15 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <p props="cpp">收到该回调后，你需要在你的 Token 服务器上生成新的 Token，并通过以下方式之一进行更新：
+            <p props="cpp">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 传入新 Token。</li>
-                            <li>调用 <codeph>leaveChannel</codeph> 离开当前频道后，再调用 <codeph>joinChannel</codeph> 加入频道时传入新 Token。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <codeph>leaveChannel</codeph> 离开频道，然后在调用 <codeph>joinChannel</codeph> 时传入新的 Token。</li>
                         </ul>
                     </li>
-                    <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新 Token。</li>
+                    <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
             <p props="ios">当 Token 过期时，SDK 会触发该回调。收到该回调后，你需要在你的 Token 服务器上生成一个新的 Token，并可以通过以下方式之一更新 Token：
@@ -42,12 +42,12 @@
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
-            <p props="android">该回调在 Token 过期时被触发。收到该回调后，你需要在 Token 服务器上生成新的 Token，并通过以下方式之一更新 Token：
+            <p props="android">该回调在 Token 过期时被触发。收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 更新 Token。</li>
-                            <li>调用 <codeph>leaveChannel</codeph> 离开当前频道，然后在调用 <codeph>joinChannel</codeph> 加入频道时传入新的 Token。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <codeph>leaveChannel</codeph> 离开频道，然后在调用 <codeph>joinChannel</codeph> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>

--- a/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_ontokenprivilegewillexpire.dita
+++ b/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_ontokenprivilegewillexpire.dita
@@ -20,44 +20,44 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <p props="cpp">当收到该回调时，你需要在 Token 服务器上生成一个新的 Token，并通过以下方式之一更新 Token：
+            <p props="cpp">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token。</li>
-                            <li>调用 <codeph>leaveChannel</codeph> 离开当前频道，然后在调用 <codeph>joinChannel</codeph> 加入频道时传入新的 Token。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <codeph>leaveChannel</codeph> 离开频道，然后在调用 <codeph>joinChannel</codeph> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
-            <p props="ios">收到该回调时，你需要在你的 Token 服务器上生成一个新的 Token，并可以通过以下方式之一更新 Token：
+            <p props="ios">收到该回调时，你需要在你的 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 加入频道时传入新的 Token。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul><ph>SDK 会在 Token 过期前 30 秒触发该回调，提醒应用更新 Token。</ph></p>
-            <p props="android">收到该回调时，你需要在 Token 服务器上生成一个新的 Token，并通过以下方式之一更新 Token：
+            <p props="android">收到该回调时，你需要在 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token。</li>
-                            <li>调用 <codeph>leaveChannel</codeph> 离开当前频道，然后在调用 <codeph>joinChannel</codeph> 加入频道时传入新的 Token。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <codeph>leaveChannel</codeph> 离开频道，然后在调用 <codeph>joinChannel</codeph> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                 </ul>
             </p>
-            <p props="mac">收到该回调时，你需要在你的 Token 服务器上生成一个新的 Token，并可以通过以下方式之一更新 Token：
+            <p props="mac">收到该回调时，你需要在你的 Token 服务器上生成新的 Token，并根据场景更新 Token：
                 <ul>
                     <li>单频道场景：
                         <ul>
-                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2"/> 加入频道时传入新的 Token。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。SDK 会通过 <xref keyref="onRenewTokenResult"/> 回调报告更新结果。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2"/> 时传入新的 Token。</li>
                         </ul>
                     </li>
                     <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>

--- a/dita/RTC-NG/API/callback_irtcengineeventhandler_onrequesttoken.dita
+++ b/dita/RTC-NG/API/callback_irtcengineeventhandler_onrequesttoken.dita
@@ -27,11 +27,11 @@
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
             <p id="desc1">在音视频互动过程中，如果 Token 失效，SDK 会触发该回调报告 Token 已过期。</p>
-            <p id="renew">当收到该回调时，你需要重新在服务端生成新的 Token，然后通过下列任意一种方式来更新 Token：
+            <p id="renew">当收到该回调时，你需要在服务端生成新的 Token，并根据场景更新 Token：
                 <ul>
                    <li>单频道场景：<ul>
-                            <li>调用 <xref keyref="renewToken"/> 来传入新的 Token。</li>
-                            <li>调用 <xref keyref="leaveChannel2"/> 离开当前频道，然后在调用 <xref keyref="joinChannel2" /> 时传入新的 Token 重新加入频道。</li>
+                            <li>调用 <xref keyref="renewToken"/> 传入新的 Token，无需先离开频道。</li>
+                            <li>如果你的 App 需要离开并重新加入频道，也可以调用 <xref keyref="leaveChannel2"/> 离开频道，然后在调用 <xref keyref="joinChannel2" /> 时传入新的 Token。</li>
                         </ul></li>
                    <li>多频道场景：调用 <xref keyref="updateChannelMediaOptionsEx"/> 传入新的 Token。</li>
                    </ul></p>

--- a/en-US/dita/RTC-NG/API/callback_irtcengineeventhandler_onrequesttoken.dita
+++ b/en-US/dita/RTC-NG/API/callback_irtcengineeventhandler_onrequesttoken.dita
@@ -27,12 +27,12 @@
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
             <p id="desc1">The SDK triggers this callback if the token expires.</p>
-            <p id="renew">When receiving this callback, you need to generate a new token on your token server and you can renew your token through one of the following ways:<ul>
+            <p id="renew">When receiving this callback, generate a new token on your token server and update it based on the scenario:<ul>
                    <li>In scenarios involving one channel:<ul>
-                            <li>Call <xref keyref="renewToken"/> to pass in the new token.</li>
-                            <li>Call <xref keyref="leaveChannel2"/> to leave the current channel and then pass in the new token when you call <xref keyref="joinChannel2" /> to join a channel.</li>
+                            <li>Call <xref keyref="renewToken"/> to pass in the new token without leaving the channel.</li>
+                            <li>If your app needs to leave and rejoin the channel, you can alternatively call <xref keyref="leaveChannel2"/> to leave the channel and pass in the new token when calling <xref keyref="joinChannel2" />.</li>
                         </ul></li>
-                   <li>In scenarios involving mutiple channels: Call <xref keyref="updateChannelMediaOptionsEx"/> to pass in the new token.</li>
+                   <li>In scenarios involving multiple channels, call <xref keyref="updateChannelMediaOptionsEx"/> to pass in the new token.</li>
                    </ul></p>
         </section>
         <section id="restriction" deliveryTarget="details">


### PR DESCRIPTION
## Summary

- Update the generated native and framework Chinese callback DITA topics.
- Update the legacy Chinese and English `onRequestToken` DITA topics for consistent source wording.
- Clarify that `renewToken` does not require leaving the channel first.

## Validation

- All six DITA files pass `xmllint --noout --nonet`.
- `git diff --check` passed.
- Native/framework ditagen and 12-platform Oxygen A/B validation passed.

Tracking: DF-012
