### PR TITLE
docs: update LogConfig file path guidance

### DIFF
--- a/dita/RTC-AIDOC-FRAMEWORK/API/class_logconfig.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/class_logconfig.dita
@@ -61,7 +61,7 @@
             <parml>
                 <plentry props="electron">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。
+                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。
 默认路径为：
                         <ul>
                             <li>macOS：
@@ -85,7 +85,7 @@
                 </plentry>
                 <plentry props="rn">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。
+                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。
 默认路径为：
                         <ul>
                             <li>Android：/storage/emulated/0/Android/data/&lt;packagename&gt;/files/agorasdk.log。</li>
@@ -104,7 +104,7 @@
                 </plentry>
                 <plentry props="flutter">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。</pd>
+                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。</pd>
                 </plentry>
                 <plentry props="flutter">
                     <pt>fileSizeInKB</pt>
@@ -117,7 +117,7 @@
                 </plentry>
                 <plentry props="unity">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。
+                    <pd>日志文件的完整路径。声网建议你使用默认的日志路径。如果你需要修改默认的日志路径，请确保你指定的路径存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。
 默认路径为：
                         <ul>
                             <li>Android：/storage/emulated/0/Android/data/&lt;packagename&gt;/files/agorasdk.log。</li>

--- a/dita/RTC-AIDOC/API/class_logconfig.dita
+++ b/dita/RTC-AIDOC/API/class_logconfig.dita
@@ -33,7 +33,7 @@
             <parml>
                 <plentry props="cpp">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议使用默认的日志目录。如果你需要修改默认目录，请确保指定的目录存在且可写。默认日志目录如下：
+                    <pd>日志文件的完整路径。声网建议使用默认的日志目录。如果你需要修改默认目录，请确保指定的目录存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。默认日志目录如下：
                         <ul>
                             <li>Android：/storage/emulated/0/Android/data/&lt;packagename&gt;/files/agorasdk.log。</li>
                             <li>iOS：App Sandbox/Library/caches/agorasdk.log。</li>
@@ -57,7 +57,7 @@
                 </plentry>
                 <plentry props="ios">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议使用默认的日志目录。如果你需要修改默认目录，请确保指定的目录存在且可写。默认日志目录如下：
+                    <pd>日志文件的完整路径。声网建议使用默认的日志目录。如果你需要修改默认目录，请确保指定的目录存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。默认日志目录如下：
                         <ul>
                             <li>iOS：AppSandbox/Library/caches/agorasdk.log</li>
                             <li>macOS：
@@ -79,7 +79,7 @@
                 </plentry>
                 <plentry props="android">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议使用默认日志目录。如果你需要修改默认目录，请确保你指定的目录已存在且具有写入权限。默认路径为 /storage/emulated/0/Android/data/&lt;packagename&gt;/files/agorasdk.log。</pd>
+                    <pd>日志文件的完整路径。声网建议使用默认日志目录。如果你需要修改默认目录，请确保你指定的目录已存在且具有写入权限。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。默认路径为 /storage/emulated/0/Android/data/&lt;packagename&gt;/files/agorasdk.log。</pd>
                 </plentry>
                 <plentry props="android">
                     <pt>fileSizeInKB</pt>
@@ -100,7 +100,7 @@
                 </plentry>
                 <plentry props="mac">
                     <pt>filePath</pt>
-                    <pd>日志文件的完整路径。声网建议使用默认的日志目录。如果你需要修改默认目录，请确保指定的目录存在且可写。默认日志目录如下：
+                    <pd>日志文件的完整路径。声网建议使用默认的日志目录。如果你需要修改默认目录，请确保指定的目录存在且可写。自定义路径必须包含日志文件名，例如 <codeph>/path/to/agorasdk.log</codeph>；如果只指定日志目录，请在目录末尾添加路径分隔符，SDK 会在该目录下生成 <codeph>agorasdk.log</codeph>。默认日志目录如下：
                         <ul>
                             <li>iOS：AppSandbox/Library/caches/agorasdk.log</li>
                             <li>macOS：


### PR DESCRIPTION
## Summary
- Sync generated Native and Framework DITA for DF-026
- Clarify that custom LogConfig.filePath values must include a log filename

## Verification
- XML parse for both DITA files
- git diff --check
- DITA-OT HTML output generated for Android, C++, iOS, macOS, Electron, Flutter, RN, and Unity

No merge or deployment included.