### PR TITLE
docs: clarify metadata truncation in C++ callback

### DIFF
--- a/dita/RTC-AIDOC/API/callback_imetadataobserver_onreadytosendmetadata.dita
+++ b/dita/RTC-AIDOC/API/callback_imetadataobserver_onreadytosendmetadata.dita
@@ -18,7 +18,7 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <note props="cpp">请确保元数据的大小不超过 <xref keyref="getMaxMetadataSize"/> 回调中设置的值。</note>
+            <note props="cpp">请确保元数据的大小不超过 <xref keyref="getMaxMetadataSize"/> 回调中设置的值。如果超过该值，SDK 会截除超出部分。</note>
             <note props="android">请确保元数据的大小不超过 <xref keyref="getMaxMetadataSize"/> 回调中设置的值。</note>
         </section>
         <section id="timing" deliveryTarget="details" props="android cpp">

--- a/en-US/dita/RTC-AIDOC/API/callback_imetadataobserver_onreadytosendmetadata.dita
+++ b/en-US/dita/RTC-AIDOC/API/callback_imetadataobserver_onreadytosendmetadata.dita
@@ -18,7 +18,7 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <note props="cpp">Make sure the size of the metadata does not exceed the value set in the <xref keyref="getMaxMetadataSize"/> callback.</note>
+            <note props="cpp">Ensure that the size of the metadata does not exceed the value set in the <xref keyref="getMaxMetadataSize"/> callback. If the metadata size exceeds this value, the SDK truncates the excess data.</note>
             <note props="android">Make sure the size of the metadata does not exceed the value set in the <xref keyref="getMaxMetadataSize"/> callback.</note>
         </section>
         <section id="timing" deliveryTarget="details" props="android cpp">


### PR DESCRIPTION
## Summary
- Clarify in Chinese and English DITA that metadata exceeding `getMaxMetadataSize` is truncated by the SDK.
- Keep the platform scope limited to C++/Windows.

## Validation
- `git diff --check`
- `xmllint --noout` for both DITA files
- DITA-OT 3.7.0 baseline/modified A/B generation completed successfully; only the target HTML changed.