### PR TITLE
docs: update RTC 4.6.4 local video event API docs

### DIFF
--- a/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
@@ -47,7 +47,16 @@
                 </plentry>
                 <plentry props="rn">
                     <pt>event</pt>
-                    <pd>本地视频事件类型，详见 <xref keyref="LOCAL_VIDEO_EVENT_TYPE"/>。</pd>
+                    <pd>本地视频事件类型：
+                        <ul>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureWindowHidden</codeph>：屏幕采集窗口被隐藏。</li>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureWindowRecoverFromHidden</codeph>：屏幕采集窗口从隐藏状态恢复。</li>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureStoppedByUser</codeph>：屏幕采集被用户停止。</li>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureSystemInternalError</codeph>：屏幕采集过程中发生系统内部错误。</li>
+                            <li><codeph>LocalVideoEventTypeCameraFocalLengthApplied</codeph>：请求的广角或超广角摄像头已应用。</li>
+                            <li><codeph>LocalVideoEventTypeCameraFocalLengthFallbackToDefault</codeph>：请求的广角或超广角摄像头无法打开，SDK 回退到默认摄像头。</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="flutter">
                     <pt>source</pt>
@@ -55,7 +64,16 @@
                 </plentry>
                 <plentry props="flutter">
                     <pt>event</pt>
-                    <pd>本地视频事件类型，详见 <xref keyref="LOCAL_VIDEO_EVENT_TYPE"/>。</pd>
+                    <pd>本地视频事件类型：
+                        <ul>
+                            <li><codeph>localVideoEventTypeScreenCaptureWindowHidden</codeph>：屏幕采集窗口被隐藏。</li>
+                            <li><codeph>localVideoEventTypeScreenCaptureWindowRecoverFromHidden</codeph>：屏幕采集窗口从隐藏状态恢复。</li>
+                            <li><codeph>localVideoEventTypeScreenCaptureStoppedByUser</codeph>：屏幕采集被用户停止。</li>
+                            <li><codeph>localVideoEventTypeScreenCaptureSystemInternalError</codeph>：屏幕采集过程中发生系统内部错误。</li>
+                            <li><codeph>localVideoEventTypeCameraFocalLengthApplied</codeph>：请求的广角或超广角摄像头已应用。</li>
+                            <li><codeph>localVideoEventTypeCameraFocalLengthFallbackToDefault</codeph>：请求的广角或超广角摄像头无法打开，SDK 回退到默认摄像头。</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="unity">
                     <pt>source</pt>

--- a/dita/RTC-AIDOC-FRAMEWORK/API/enum_localvideoeventtype.dita
+++ b/dita/RTC-AIDOC-FRAMEWORK/API/enum_localvideoeventtype.dita
@@ -59,6 +59,14 @@
                     <pt>LocalVideoEventTypeScreenCaptureSystemInternalError</pt>
                     <pd>（4）：屏幕采集过程中发生系统内部错误，仅适用于 Android 平台。</pd>
                 </plentry>
+                <plentry props="rn">
+                    <pt>LocalVideoEventTypeCameraFocalLengthApplied</pt>
+                    <pd>（5）：请求的广角或超广角摄像头已应用，仅适用于 Android 平台。</pd>
+                </plentry>
+                <plentry props="rn">
+                    <pt>LocalVideoEventTypeCameraFocalLengthFallbackToDefault</pt>
+                    <pd>（6）：请求的广角或超广角摄像头无法打开，SDK 回退到默认摄像头，仅适用于 Android 平台。</pd>
+                </plentry>
                 <plentry props="flutter">
                     <pt>localVideoEventTypeScreenCaptureWindowHidden</pt>
                     <pd>（1）：屏幕采集窗口被隐藏，仅适用于 Android 平台。</pd>
@@ -74,6 +82,14 @@
                 <plentry props="flutter">
                     <pt>localVideoEventTypeScreenCaptureSystemInternalError</pt>
                     <pd>（4）：屏幕采集过程中发生系统内部错误，仅适用于 Android 平台。</pd>
+                </plentry>
+                <plentry props="flutter">
+                    <pt>localVideoEventTypeCameraFocalLengthApplied</pt>
+                    <pd>（5）：请求的广角或超广角摄像头已应用，仅适用于 Android 平台。</pd>
+                </plentry>
+                <plentry props="flutter">
+                    <pt>localVideoEventTypeCameraFocalLengthFallbackToDefault</pt>
+                    <pd>（6）：请求的广角或超广角摄像头无法打开，SDK 回退到默认摄像头，仅适用于 Android 平台。</pd>
                 </plentry>
                 <plentry props="unity">
                     <pt>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_WINDOW_HIDDEN</pt>

--- a/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
+++ b/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
@@ -50,6 +50,8 @@
                             <li><codeph>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_WINDOW_RECOVER_FROM_HIDDEN</codeph>：屏幕采集窗口从隐藏状态恢复。</li>
                             <li><codeph>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_STOPPED_BY_USER</codeph>：屏幕采集被用户停止。</li>
                             <li><codeph>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_SYSTEM_INTERNAL_ERROR</codeph>：屏幕采集过程中发生系统内部错误。</li>
+                            <li><codeph>LOCAL_VIDEO_EVENT_TYPE_CAMERA_FOCAL_LENGTH_APPLIED</codeph>：请求的广角或超广角摄像头已应用。</li>
+                            <li><codeph>LOCAL_VIDEO_EVENT_TYPE_CAMERA_FOCAL_LENGTH_FALLBACK_TO_DEFAULT</codeph>：请求的广角或超广角摄像头无法打开，SDK 回退到默认摄像头。</li>
                         </ul>
                     </pd>
                 </plentry>

--- a/en-US/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
+++ b/en-US/dita/RTC-AIDOC-FRAMEWORK/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
@@ -47,7 +47,16 @@
                 </plentry>
                 <plentry props="rn">
                     <pt>event</pt>
-                    <pd>Type of local video event. See <xref keyref="LOCAL_VIDEO_EVENT_TYPE"/>.</pd>
+                    <pd>Type of local video event:
+                        <ul>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureWindowHidden</codeph>: The screen capture window is hidden.</li>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureWindowRecoverFromHidden</codeph>: The screen capture window recovers from the hidden state.</li>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureStoppedByUser</codeph>: Screen capture is stopped by the user.</li>
+                            <li><codeph>LocalVideoEventTypeScreenCaptureSystemInternalError</codeph>: A system internal error occurs during screen capture.</li>
+                            <li><codeph>LocalVideoEventTypeCameraFocalLengthApplied</codeph>: The requested wide-angle or ultra-wide-angle camera is applied.</li>
+                            <li><codeph>LocalVideoEventTypeCameraFocalLengthFallbackToDefault</codeph>: The requested wide-angle or ultra-wide-angle camera cannot be opened, and the SDK falls back to the default camera.</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="flutter">
                     <pt>source</pt>
@@ -55,7 +64,16 @@
                 </plentry>
                 <plentry props="flutter">
                     <pt>event</pt>
-                    <pd>Type of local video event. See <xref keyref="LOCAL_VIDEO_EVENT_TYPE"/>.</pd>
+                    <pd>Type of local video event:
+                        <ul>
+                            <li><codeph>localVideoEventTypeScreenCaptureWindowHidden</codeph>: The screen capture window is hidden.</li>
+                            <li><codeph>localVideoEventTypeScreenCaptureWindowRecoverFromHidden</codeph>: The screen capture window recovers from the hidden state.</li>
+                            <li><codeph>localVideoEventTypeScreenCaptureStoppedByUser</codeph>: Screen capture is stopped by the user.</li>
+                            <li><codeph>localVideoEventTypeScreenCaptureSystemInternalError</codeph>: A system internal error occurs during screen capture.</li>
+                            <li><codeph>localVideoEventTypeCameraFocalLengthApplied</codeph>: The requested wide-angle or ultra-wide-angle camera is applied.</li>
+                            <li><codeph>localVideoEventTypeCameraFocalLengthFallbackToDefault</codeph>: The requested wide-angle or ultra-wide-angle camera cannot be opened, and the SDK falls back to the default camera.</li>
+                        </ul>
+                    </pd>
                 </plentry>
                 <plentry props="unity">
                     <pt>source</pt>

--- a/en-US/dita/RTC-AIDOC-FRAMEWORK/API/enum_localvideoeventtype.dita
+++ b/en-US/dita/RTC-AIDOC-FRAMEWORK/API/enum_localvideoeventtype.dita
@@ -59,6 +59,14 @@
                     <pt>LocalVideoEventTypeScreenCaptureSystemInternalError</pt>
                     <pd>(4): A system internal error occurs during screen capture. (Android only)</pd>
                 </plentry>
+                <plentry props="rn">
+                    <pt>LocalVideoEventTypeCameraFocalLengthApplied</pt>
+                    <pd>(5): The requested wide-angle or ultra-wide-angle camera is applied. (Android only)</pd>
+                </plentry>
+                <plentry props="rn">
+                    <pt>LocalVideoEventTypeCameraFocalLengthFallbackToDefault</pt>
+                    <pd>(6): The requested wide-angle or ultra-wide-angle camera cannot be opened, and the SDK falls back to the default camera. (Android only)</pd>
+                </plentry>
                 <plentry props="flutter">
                     <pt>localVideoEventTypeScreenCaptureWindowHidden</pt>
                     <pd>(1): The screen capture window is hidden (Android only).</pd>
@@ -74,6 +82,14 @@
                 <plentry props="flutter">
                     <pt>localVideoEventTypeScreenCaptureSystemInternalError</pt>
                     <pd>(4): A system internal error occurs during screen capture (Android only).</pd>
+                </plentry>
+                <plentry props="flutter">
+                    <pt>localVideoEventTypeCameraFocalLengthApplied</pt>
+                    <pd>(5): The requested wide-angle or ultra-wide-angle camera is applied. (Android only)</pd>
+                </plentry>
+                <plentry props="flutter">
+                    <pt>localVideoEventTypeCameraFocalLengthFallbackToDefault</pt>
+                    <pd>(6): The requested wide-angle or ultra-wide-angle camera cannot be opened, and the SDK falls back to the default camera. (Android only)</pd>
                 </plentry>
                 <plentry props="unity">
                     <pt>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_WINDOW_HIDDEN</pt>

--- a/en-US/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
+++ b/en-US/dita/RTC-AIDOC/API/callback_irtcengineeventhandler_onlocalvideoevent.dita
@@ -50,6 +50,8 @@
                             <li><codeph>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_WINDOW_RECOVER_FROM_HIDDEN</codeph>: The screen capture window recovers from being hidden.</li>
                             <li><codeph>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_STOPPED_BY_USER</codeph>: Screen capture is stopped by the user.</li>
                             <li><codeph>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_SYSTEM_INTERNAL_ERROR</codeph>: A system internal error occurs during screen capture.</li>
+                            <li><codeph>LOCAL_VIDEO_EVENT_TYPE_CAMERA_FOCAL_LENGTH_APPLIED</codeph>: The requested wide-angle or ultra-wide-angle camera is applied.</li>
+                            <li><codeph>LOCAL_VIDEO_EVENT_TYPE_CAMERA_FOCAL_LENGTH_FALLBACK_TO_DEFAULT</codeph>: The requested wide-angle or ultra-wide-angle camera cannot be opened, and the SDK falls back to the default camera.</li>
                         </ul>
                     </pd>
                 </plentry>

--- a/en-US/dita/RTC-AIDOC/API/enum_localvideoeventtype.dita
+++ b/en-US/dita/RTC-AIDOC/API/enum_localvideoeventtype.dita
@@ -31,6 +31,14 @@
                     <pt>LOCAL_VIDEO_EVENT_TYPE_SCREEN_CAPTURE_SYSTEM_INTERNAL_ERROR</pt>
                     <pd>(4): A system internal error occurs during screen capture (Android only).</pd>
                 </plentry>
+                <plentry props="cpp">
+                    <pt>LOCAL_VIDEO_EVENT_TYPE_CAMERA_FOCAL_LENGTH_APPLIED</pt>
+                    <pd>(5): The requested wide-angle or ultra-wide-angle camera is applied (Android only).</pd>
+                </plentry>
+                <plentry props="cpp">
+                    <pt>LOCAL_VIDEO_EVENT_TYPE_CAMERA_FOCAL_LENGTH_FALLBACK_TO_DEFAULT</pt>
+                    <pd>(6): The requested wide-angle or ultra-wide-angle camera cannot be opened, and the SDK falls back to the default camera (Android only).</pd>
+                </plentry>
             </parml>
         </section>
     </refbody>


### PR DESCRIPTION
## Summary
- Update RTC native Android local video event callback documentation for focal-length events.
- Update RTC framework RN/Flutter LocalVideoEventType and onLocalVideoEvent DITA docs in Chinese and English.
- Align DITA source with the RN/Flutter 4.6.4 SDK API changes.

## Validation
- xmllint --noout on touched DITA files.
- git diff --check HEAD~1..HEAD.