### PR TITLE
fix: update DF-048 datastream API DITA

### DIFF
--- a/dita/RTC-AIDOC/API/api_irtcengine_createdatastream2.dita
+++ b/dita/RTC-AIDOC/API/api_irtcengine_createdatastream2.dita
@@ -22,7 +22,7 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <p props="cpp">该方法不保证数据传输的可靠性。如果数据包在发送后五秒内未被接收，SDK 会直接丢弃该数据包。与 <codeph>createDataStream</codeph> 方法相比，该方法适用于对实时性要求高但可容忍部分数据丢失的场景。</p>
+            <p props="cpp"><xref keyref="createDataStream2"/> 与 <xref keyref="createDataStream1"/> 相比，不保证数据传输的可靠性。如果数据包在发送后五秒内未被接收，SDK 会直接丢弃该数据包。该方法适用于对实时性要求高但可容忍部分数据丢失的场景。</p>
             <p props="ios">与 <xref keyref="createDataStream1"/> 方法相比，该方法不保证数据传输的可靠性。如果数据包在发送后五秒内未被接收，SDK 会直接丢弃该数据包。你可以在加入频道前或加入频道后调用该方法。</p>
             <p props="android">该方法不保证数据传输的可靠性。如果数据包在发送后五秒内未被接收，SDK 会直接丢弃该数据。</p>
             <p props="mac">与 <xref keyref="createDataStream1"/> 方法相比，该方法不保证数据传输的可靠性。如果数据包在发送后五秒内未被接收，SDK 会直接丢弃该数据包。你可以在加入频道前或加入频道后调用该方法。</p>

--- a/dita/RTC-AIDOC/API/api_irtcengine_sendstreammessage.dita
+++ b/dita/RTC-AIDOC/API/api_irtcengine_sendstreammessage.dita
@@ -22,7 +22,12 @@
             </p>
         </section>
         <section id="detailed_desc" deliveryTarget="details" otherprops="no-title">
-            <p props="cpp">调用 <codeph>createDataStream</codeph> 后，可以调用该方法向频道内的所有用户发送数据流消息。</p>
+            <p props="cpp">调用 <codeph>createDataStream</codeph> 后，可以调用该方法向频道内的所有用户发送数据流消息。SDK 对该方法有限制：
+                <ul>
+                    <li>每个客户端在频道中最多可同时拥有 5 个数据通道，所有数据通道共享的总包比特率上限为 30 KB/s；</li>
+                    <li>每个数据通道每秒最多可发送 60 个数据包，每个数据包最大为 1 KB。</li>
+                </ul>
+            </p>
             <p props="ios">调用 <xref keyref="createDataStream2"/> 后，你可以使用此方法向频道内的所有用户发送数据流消息。SDK 对此方法有以下限制：
                 <ul>
                     <li>每个客户端在频道中最多可同时拥有 5 个数据通道，所有数据通道共享的总包比特率上限为 30 KB/s。</li>


### PR DESCRIPTION
## Summary
- DF-048: update Windows RTC DataStream API DITA source text.
- Clarify createDataStream [2/2] by explicitly comparing it with createDataStream [1/2].
- Add the sendStreamMessage data-channel and send-limit explanation aligned with sendStreamMessageEx.

## Verification
- ./scripts/aidoc dita parse passed in doc_ai_tool.
- ditagen generated the target DITA files successfully.
- xmllint --noout passed for updated DITA files.
- git diff --check passed.

## Notes
- Oxygen CLI publish was attempted with the bundled JRE, but the local CLI path resolution hit ditaval/topicpull/keyref issues. HTML was updated in shengwang-doc-source from the generated DITA target fragments as a controlled fallback.